### PR TITLE
Improve drawing; enable high quality export

### DIFF
--- a/SignatureTest/SignatureTest/ViewController.swift
+++ b/SignatureTest/SignatureTest/ViewController.swift
@@ -32,7 +32,7 @@ class ViewController: UIViewController, YPDrawSignatureViewDelegate {
   
   @IBAction func saveSignature(sender: UIButton) {
     // Getting the Signature Image from self.drawSignatureView using the method getSignature().
-    if let signatureImage = self.drawSignatureView.getSignature() {
+    if let signatureImage = self.drawSignatureView.getSignature(scale: 10) {
       // Saving signatureImage from the line above to the Photo Roll.
       // The first time you do this, the app asks for access to your pictures.
       UIImageWriteToSavedPhotosAlbum(signatureImage, nil, nil, nil)

--- a/SignatureTest/SignatureTest/YPDrawSignatureView.swift
+++ b/SignatureTest/SignatureTest/YPDrawSignatureView.swift
@@ -129,29 +129,31 @@ public class YPDrawSignatureView: UIView {
     }
     
     // Save the Signature as an UIImage
-    public func getSignature() -> UIImage? {
-        UIGraphicsBeginImageContext(CGSizeMake(self.bounds.size.width, self.bounds.size.height))
-        if let context = UIGraphicsGetCurrentContext() {
-            self.layer.renderInContext(context)
-            let signature = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            return signature
-        } else {
-            return nil
-        }
+    public func getSignature(scale scale:CGFloat = 1) -> UIImage? {
+        if !containsSignature { return nil }
+        UIGraphicsBeginImageContextWithOptions(self.bounds.size, false, scale)
+        self.path.stroke()
+        let signature = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return signature
     }
     
     // Save the Signature (cropped of outside white space) as a UIImage
-    public func getSignatureCropped() -> UIImage? {
-        if let fullRender = getSignature() {
-            if let imageRef = CGImageCreateWithImageInRect(fullRender.CGImage, path.bounds) {
-                return UIImage(CGImage: imageRef)
-            } else {
-                return nil
-            }
-        } else {
-            return nil
-        }
+    public func getSignatureCropped(scale scale:CGFloat = 1) -> UIImage? {
+        guard let fullRender = getSignature(scale:scale) else { return nil }
+        let bounds = scaleRect(path.bounds.insetBy(dx: -strokeWidth/2, dy: -strokeWidth/2), byFactor: scale)
+        guard let imageRef = CGImageCreateWithImageInRect(fullRender.CGImage, bounds) else { return nil }
+        return UIImage(CGImage: imageRef)
+    }
+    
+    func scaleRect(rect: CGRect, byFactor factor: CGFloat) -> CGRect
+    {
+        var scaledRect = rect
+        scaledRect.origin.x *= factor
+        scaledRect.origin.y *= factor
+        scaledRect.size.width *= factor
+        scaledRect.size.height *= factor
+        return scaledRect
     }
 }
 

--- a/SignatureTest/SignatureTest/YPDrawSignatureView.swift
+++ b/SignatureTest/SignatureTest/YPDrawSignatureView.swift
@@ -55,6 +55,7 @@ public class YPDrawSignatureView: UIView {
         
         self.backgroundColor = self.signatureBackgroundColor
         self.path.lineWidth = self.strokeWidth
+        self.path.lineJoinStyle = CGLineJoin.Round
     }
     
     override public init(frame: CGRect) {
@@ -62,6 +63,7 @@ public class YPDrawSignatureView: UIView {
         
         self.backgroundColor = self.signatureBackgroundColor
         self.path.lineWidth = self.strokeWidth
+        self.path.lineJoinStyle = CGLineJoin.Round
     }
     
     // MARK: - Draw

--- a/source/YPDrawSignatureView.swift
+++ b/source/YPDrawSignatureView.swift
@@ -129,29 +129,31 @@ public class YPDrawSignatureView: UIView {
     }
     
     // Save the Signature as an UIImage
-    public func getSignature() -> UIImage? {
-        UIGraphicsBeginImageContext(CGSizeMake(self.bounds.size.width, self.bounds.size.height))
-        if let context = UIGraphicsGetCurrentContext() {
-            self.layer.renderInContext(context)
-            let signature = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            return signature
-        } else {
-            return nil
-        }
+    public func getSignature(scale scale:CGFloat = 1) -> UIImage? {
+        if !containsSignature { return nil }
+        UIGraphicsBeginImageContextWithOptions(self.bounds.size, false, scale)
+        self.path.stroke()
+        let signature = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return signature
     }
     
     // Save the Signature (cropped of outside white space) as a UIImage
-    public func getSignatureCropped() -> UIImage? {
-        if let fullRender = getSignature() {
-            if let imageRef = CGImageCreateWithImageInRect(fullRender.CGImage, path.bounds) {
-                return UIImage(CGImage: imageRef)
-            } else {
-                return nil
-            }
-        } else {
-            return nil
-        }
+    public func getSignatureCropped(scale scale:CGFloat = 1) -> UIImage? {
+        guard let fullRender = getSignature(scale:scale) else { return nil }
+        let bounds = scaleRect(path.bounds.insetBy(dx: -strokeWidth/2, dy: -strokeWidth/2), byFactor: scale)
+        guard let imageRef = CGImageCreateWithImageInRect(fullRender.CGImage, bounds) else { return nil }
+        return UIImage(CGImage: imageRef)
+    }
+    
+    func scaleRect(rect: CGRect, byFactor factor: CGFloat) -> CGRect
+    {
+        var scaledRect = rect
+        scaledRect.origin.x *= factor
+        scaledRect.origin.y *= factor
+        scaledRect.size.width *= factor
+        scaledRect.size.height *= factor
+        return scaledRect
     }
 }
 

--- a/source/YPDrawSignatureView.swift
+++ b/source/YPDrawSignatureView.swift
@@ -55,6 +55,7 @@ public class YPDrawSignatureView: UIView {
         
         self.backgroundColor = self.signatureBackgroundColor
         self.path.lineWidth = self.strokeWidth
+        self.path.lineJoinStyle = CGLineJoin.Round
     }
     
     override public init(frame: CGRect) {
@@ -62,6 +63,7 @@ public class YPDrawSignatureView: UIView {
         
         self.backgroundColor = self.signatureBackgroundColor
         self.path.lineWidth = self.strokeWidth
+        self.path.lineJoinStyle = CGLineJoin.Round
     }
     
     // MARK: - Draw


### PR DESCRIPTION
- Use rounded ends instead of the default sharp corner, as this resembles a handwritten signature more closely
- Add `scale` parameter in `getSignature` to allow drawing the signature in higher
  resolution (default value of 1 for backwards compatibility)
- Take line width into account when cropping the signature, so the
  stroke isn’t cut off at the edge
- Drawn signature now has a proper alpha channel with a transparent
  background (instead of the previous white background)
