### PR TITLE
Modified Delegate to pass reference of YPDrawSignatureView

### DIFF
--- a/SignatureTest/SignatureTest/ViewController.swift
+++ b/SignatureTest/SignatureTest/ViewController.swift
@@ -56,13 +56,13 @@ class ViewController: UIViewController, YPSignatureDelegate {
     // didStart() is called right after the first touch is registered in the view.
     // For example, this can be used if the view is embedded in a scroll view, temporary
     // stopping it from scrolling while signing.
-    func didStart() {
+    func didStart(_ view : YPDrawSignatureView) {
         print("Started Drawing")
     }
     
     // didFinish() is called rigth after the last touch of a gesture is registered in the view.
     // Can be used to enabe scrolling in a scroll view if it has previous been disabled.
-    func didFinish() {
+    func didFinish(_ view : YPDrawSignatureView) {
         print("Finished Drawing")
     }
 }

--- a/SignatureTest/SignatureTest/YPDrawSignatureView.swift
+++ b/SignatureTest/SignatureTest/YPDrawSignatureView.swift
@@ -218,8 +218,8 @@ final public class YPDrawSignatureView: UIView {
 /// - optional didFinish()
 @objc
 public protocol YPSignatureDelegate: class {
-    func didStart()
-    func didFinish()
+    func didStart(_ view : YPDrawSignatureView)
+    func didFinish(_ view : YPDrawSignatureView)
     @available(*, unavailable, renamed: "didFinish()")
     func startedDrawing()
     @available(*, unavailable, renamed: "didFinish()")
@@ -227,6 +227,6 @@ public protocol YPSignatureDelegate: class {
 }
 
 extension YPSignatureDelegate {
-    func didStart() {}
-    func didFinish() {}
+    func didStart(_ view : YPDrawSignatureView) {}
+    func didFinish(_ view : YPDrawSignatureView) {}
 }

--- a/Sources/YPDrawSignatureView.swift
+++ b/Sources/YPDrawSignatureView.swift
@@ -98,7 +98,7 @@ final public class YPDrawSignatureView: UIView {
         }
         
         if let delegate = delegate {
-            delegate.didStart()
+            delegate.didStart(self)
         }
     }
     
@@ -133,7 +133,7 @@ final public class YPDrawSignatureView: UIView {
         }
         
         if let delegate = delegate {
-            delegate.didFinish()
+            delegate.didFinish(self)
         }
     }
     
@@ -206,19 +206,19 @@ final public class YPDrawSignatureView: UIView {
 // MARK: - Protocol definition for YPDrawSignatureViewDelegate
 /// ## YPDrawSignatureViewDelegate Protocol
 /// YPDrawSignatureViewDelegate:
-/// - optional didStart()
-/// - optional didFinish()
+/// - optional didStart(_ view : YPDrawSignatureView)
+/// - optional didFinish(_ view : YPDrawSignatureView)
 @objc
 public protocol YPSignatureDelegate: class {
-    func didStart()
-    func didFinish()
-    @available(*, unavailable, renamed: "didFinish()")
+    func didStart(_ view : YPDrawSignatureView)
+    func didFinish(_ view : YPDrawSignatureView)
+    @available(*, unavailable, renamed: "didFinish(_ view : YPDrawSignatureView)")
     func startedDrawing()
-    @available(*, unavailable, renamed: "didFinish()")
+    @available(*, unavailable, renamed: "didFinish(_ view : YPDrawSignatureView)")
     func finishedDrawing()
 }
 
 extension YPSignatureDelegate {
-    func didStart() {}
-    func didFinish() {}
+    func didStart(_ view : YPDrawSignatureView) {}
+    func didFinish(_ view : YPDrawSignatureView) {}
 }


### PR DESCRIPTION
This change allows the developer to become notified of which view "didStart" or "didFinish"