### PR TITLE
Ignore gesture recognizers

### DIFF
--- a/Sources/YPDrawSignatureView.swift
+++ b/Sources/YPDrawSignatureView.swift
@@ -139,6 +139,11 @@ final public class YPDrawSignatureView: UIView {
         }
     }
     
+    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // prevent gesture recognizers (e.g. UIPanGestureRecognizer in a FormSheet) from capturing the touches
+        return false
+    }
+    
     // MARK: - Methods for interacting with Signature View
     
     // Clear the Signature View


### PR DESCRIPTION
This PR introduces ignoring of `UIGestureRecognizer` events on the signature view.

Reason: Starting with iOS 13, modal views (e.g. `.formSheet`) can be cancelled by swiping them down. If a `YPDrawSignatureView` is displayed in such a modal view, drawing is impossible because a `UIPanGestureRecognizer` captures the touches before they reach the signature view.