### PR TITLE
Support Swift Tools version 5 (Xcode 11)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,18 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
-    name: "YPDrawSignature"
+    name: "YPDrawSignature",
+    platforms: [.iOS(.v11)],
+    products: [
+        .library(name: "YPDrawSignature", targets: ["YPDrawSignature"])
+    ],
+    targets: [
+      .target(
+        name: "YPDrawSignature",
+        path: "",
+        sources: ["Sources"]
+      )
+    ],
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
This PR allows importing YPDrawSignatureView directly inside of Xcode 11 with SPM.
I might be wrong regarding the minimum supported iOS version, feel free to fix it.