### PR TITLE
Adds missing key to Info.plist

### DIFF
--- a/SignatureTest/SignatureTest/Info.plist
+++ b/SignatureTest/SignatureTest/Info.plist
@@ -45,5 +45,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Saves signatures to photo library</string>
 </dict>
 </plist>


### PR DESCRIPTION
* Adds missing key (`NSPhotoLibraryAddUsageDescription`) to Info.plist
    * Otherwise, the demo app crashes whenever signatures are attempted to be saved
<img width="505" alt="Screen Shot 2020-06-05 at 2 07 46 PM" src="https://user-images.githubusercontent.com/2531425/83924208-e4643100-a738-11ea-9bd8-cd542a59e659.png">
